### PR TITLE
Clear unused parameter for GetModAsync and GetModsPageAsync

### DIFF
--- a/Services/CacheDb.cs
+++ b/Services/CacheDb.cs
@@ -882,7 +882,7 @@ LIMIT 1;";
 
                 var chunk = await ForgeClient.GetModsPageAsync(
                     page, pageSize,
-                    true, true, true, true,
+                    true, true,
                     "",
                     "-updated_at",
                     true,

--- a/Services/ForgeClient.cs
+++ b/Services/ForgeClient.cs
@@ -275,8 +275,6 @@ public static class ForgeClient
 
     public static async Task<ModSummary?> GetModAsync(
         int modId,
-        bool includeOwner = false,
-        bool includeAuthors = false,
         bool includeCategory = true,
         bool includeVersions = false,
         bool includeSourceLinks = false,
@@ -337,8 +335,6 @@ public static class ForgeClient
         int page,
         int perPage,
         bool includeVersions,
-        bool includeOwner,
-        bool includeAuthors,
         bool includeCategory,
         string query,
         string sortApi,

--- a/Services/SelfUpdateChecker.cs
+++ b/Services/SelfUpdateChecker.cs
@@ -32,7 +32,7 @@ public static class SelfUpdateChecker
                 return;
             }
 
-            var mod = await ForgeClient.GetModAsync(ModManagerForgeID, includeOwner: false, includeAuthors: false, includeCategory: false, includeVersions: false,
+            var mod = await ForgeClient.GetModAsync(ModManagerForgeID, includeCategory: false, includeVersions: false,
                 includeSourceLinks: false, ct: ct).ConfigureAwait(false);
 
             var pageUrl = mod?.detail_url ?? "";

--- a/Views/BrowseModsPage.axaml.cs
+++ b/Views/BrowseModsPage.axaml.cs
@@ -1358,8 +1358,6 @@ public partial class BrowseModsPage : UserControl
                 var mod = await ForgeClient.GetModAsync(r.ModId,
                     false,
                     false,
-                    false,
-                    false,
                     true,
                     App.ShutdownToken);
 


### PR DESCRIPTION
I was currently fixing the network related issues but saw that you already fixed them (damn - one hour too late). I removed some parameter left in the code without any functionality.