### PR TITLE
Migrate to the new Forge at sp-mod.com

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -180,7 +180,7 @@ public class App : Application
             {
                 const string githubIssues = "https://github.com/Drexira/DragonDen-ModManager/issues";
                 const string discordInvite = "https://discord.gg/WelcomeToTarkov";
-                const string modPage = "https://forge.sp-tarkov.com/mod/2396/dragon-den-mod-manager";
+                const string modPage = "https://sp-mod.com";
 
                 if (!Config.UI.ExpertMode)
                 {

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This readme is for developers who want to contribute.
 * .NET 9 SDK
 * Windows 10/11
     * Primary target: Windows 10/11
-* A valid Forge API token
+* A Forge API token (optional — the new sp-mod.com API works without one)
 * An SPT root folder (to detect SPT version and manage installs)
 
 ---

--- a/Services/Config.cs
+++ b/Services/Config.cs
@@ -28,7 +28,7 @@ public sealed class Config
             },
             Forge = new ForgeSection
             {
-                BaseUrl = "https://forge.sp-tarkov.com",
+                BaseUrl = "https://sp-mod.com",
                 Token = ""
             },
             UI = new UISection
@@ -94,8 +94,9 @@ public sealed class Config
         if (string.IsNullOrWhiteSpace(Paths.ServerModsRelative))
             Paths.ServerModsRelative = "SPT/user/mods";
 
-        if (string.IsNullOrWhiteSpace(Forge.BaseUrl))
-            Forge.BaseUrl = "https://forge.sp-tarkov.com";
+        if (string.IsNullOrWhiteSpace(Forge.BaseUrl) ||
+            Forge.BaseUrl.Contains("sp-tarkov.com", StringComparison.OrdinalIgnoreCase))
+            Forge.BaseUrl = "https://sp-mod.com";
 
         Forge.Token ??= "";
 
@@ -131,7 +132,7 @@ public sealed class PathsSection
 
 public sealed class ForgeSection
 {
-    public string BaseUrl { get; set; } = "https://forge.sp-tarkov.com";
+    public string BaseUrl { get; set; } = "https://sp-mod.com";
     public string Token { get; set; } = "";
 }
 

--- a/Services/ForgeClient.cs
+++ b/Services/ForgeClient.cs
@@ -38,7 +38,7 @@ public static class ForgeClient
         Timeout = TimeSpan.FromSeconds(100)
     };
 
-    private static string BaseUrl => App.Config.Forge.BaseUrl?.TrimEnd('/') ?? "https://forge.sp-tarkov.com";
+    private static string BaseUrl => App.Config.Forge.BaseUrl?.TrimEnd('/') ?? "https://sp-mod.com";
     public static event Action<string>? StatusMessage;
 
     private static HttpRequestMessage NewGet(string url)
@@ -547,7 +547,7 @@ public static class ForgeClient
                 Version = v.GetPropertyOrDefault("version", (string?)null),
                 Link = v.GetPropertyOrDefault("link", (string?)null),
                 Description = v.GetPropertyOrDefault("description", (string?)null),
-                SptVersionConstraint = v.GetPropertyOrDefault("spt_version_constraint", (string?)null),
+                SptVersionConstraint = v.GetPropertyOrDefault("spt_version_constraint", (string?)null)?.Trim(),
                 Downloads = v.GetPropertyOrDefault("downloads", 0L),
                 PublishedAt = dto,
                 ContentLength = v.GetPropertyOrDefault("content_length", 0L),

--- a/Services/SelfUpdateChecker.cs
+++ b/Services/SelfUpdateChecker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -15,6 +15,13 @@ public static class SelfUpdateChecker
 
     public static async Task CheckOnStartupAsync(Window owner, System.Threading.CancellationToken ct = default)
     {
+        // Fork note: the DragonDen Mod Manager listing (mod 2396) was not migrated to the
+        // new Forge (sp-mod.com), so this update channel is dead — querying it 404s and
+        // triggers the full retry/backoff path on every launch. Disabled until this fork
+        // has its own release channel (e.g. GitHub releases).
+        await Task.CompletedTask;
+        return;
+#pragma warning disable CS0162 // unreachable — kept for when an update channel returns
         try
         {
             var versions = await ForgeClient.GetAllVersionsAsync(ModManagerForgeID, ct).ConfigureAwait(false);
@@ -52,6 +59,7 @@ public static class SelfUpdateChecker
             Logger.Error($"[SelfUpdateChecker] CheckOnStartupAsync: {ex}");
         }
     }
+#pragma warning restore CS0162
 
     public static string GetCurrentAppVersion()
     {

--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -63,7 +63,11 @@ public partial class MainWindow : Window
 
     private async void OnOpenedAsync(object? s, EventArgs e)
     {
-        while (string.IsNullOrWhiteSpace(App.Config.Forge.Token))
+        // Token is optional (the Forge API works unauthenticated). Only offer the prompt
+        // once, on genuine first run (before the SPT folder is configured), and let the
+        // user skip it. Closing the dialog window exits the app; skipping continues.
+        if (string.IsNullOrWhiteSpace(App.Config.Paths.SptRoot) &&
+            string.IsNullOrWhiteSpace(App.Config.Forge.Token))
         {
             var dlg = new TokenDialog();
             var res = await dlg.ShowDialog<TokenDialog.Result?>(this) ?? TokenDialog.Result.CloseApp;

--- a/Views/TokenDialog.axaml
+++ b/Views/TokenDialog.axaml
@@ -6,7 +6,7 @@
         CanResize="False"
         SystemDecorations="None"
         WindowStartupLocation="CenterOwner"
-        Title="Forge Token Required">
+        Title="Forge Token (optional)">
 
     <Window.Resources>
         <SolidColorBrush x:Key="Dd.Panel" Color="#12161A" />
@@ -111,12 +111,12 @@
 
         <Grid Grid.Row="1" Margin="16" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="12">
             <StackPanel Spacing="6">
-                <TextBlock Text="Forge API token required"
+                <TextBlock Text="Forge API token (optional)"
                            FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource Dd.Text}" />
                 <TextBlock TextWrapping="Wrap"
                            Foreground="{StaticResource Dd.Subtle}">
-                    You can create a token on the Forge website.
-                    Make sure the token has only <Run Text="Read" Foreground="{StaticResource Dd.Warn}" /> permissions checked.
+                    The Forge works without a token, so this is optional. You can add one now or skip and continue.
+                    If you add a token, make sure it has only <Run Text="Read" Foreground="{StaticResource Dd.Warn}" /> permissions checked.
                 </TextBlock>
                 <Button Classes="link"
                         Content="Open Forge API Tokens page"
@@ -145,7 +145,7 @@
 
             <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
                 <Button x:Name="SetBtn" Content="Save Token" Classes="btn success" />
-                <Button x:Name="CloseBtn" Content="Close" Classes="btn danger" />
+                <Button x:Name="CloseBtn" Content="Continue without token" Classes="btn" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/Views/TokenDialog.axaml.cs
+++ b/Views/TokenDialog.axaml.cs
@@ -17,6 +17,7 @@ public partial class TokenDialog : Window
     {
         None,
         Set,
+        Skip,
         CloseApp
     }
 
@@ -24,7 +25,7 @@ public partial class TokenDialog : Window
     {
         InitializeComponent();
         SetBtn.Click += OnSetAsync;
-        CloseBtn.Click += (_, __) => Close(Result.CloseApp);
+        CloseBtn.Click += (_, __) => Close(Result.Skip);
     }
 
     private async void OnSetAsync(object? s, RoutedEventArgs e)
@@ -32,8 +33,10 @@ public partial class TokenDialog : Window
         var token = (TokenBox.Text ?? "").Trim();
         if (string.IsNullOrWhiteSpace(token))
         {
-            Notifications.Current.ShowWarning("Missing Token", "Please enter your Forge API token before continuing.");
-            Logger.Warn("[TokenDialog] No token entered by user.");
+            // The new Forge API works unauthenticated, so a token is optional.
+            // Proceed without one instead of blocking the user.
+            Logger.Info("[TokenDialog] No token entered; continuing without a Forge token.");
+            Close(Result.Skip);
             return;
         }
 
@@ -75,7 +78,7 @@ public partial class TokenDialog : Window
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
             http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
-            using var resp = await http.GetAsync("https://forge.sp-tarkov.com/api/v0/ping");
+            using var resp = await http.GetAsync($"{Base()}/api/v0/ping");
             if (!resp.IsSuccessStatusCode) return false;
 
             using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
@@ -100,7 +103,7 @@ public partial class TokenDialog : Window
             http.DefaultRequestHeaders.Authorization =
                 new AuthenticationHeaderValue("Bearer", token);
 
-            using var resp = await http.GetAsync("https://forge.sp-tarkov.com/api/v0/mods?per_page=1&page=1");
+            using var resp = await http.GetAsync($"{Base()}/api/v0/mods?per_page=1&page=1");
             if (resp.StatusCode == HttpStatusCode.Unauthorized ||
                 resp.StatusCode == HttpStatusCode.Forbidden)
                 return false;
@@ -124,7 +127,7 @@ public partial class TokenDialog : Window
     {
         try
         {
-            var url = "https://forge.sp-tarkov.com/user/api-tokens";
+            var url = Base();
             _ = Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
         }
         catch (Exception ex)
@@ -139,5 +142,11 @@ public partial class TokenDialog : Window
         var show = ShowToggle.IsChecked == true;
         TokenBox.PasswordChar = show ? '\0' : '•';
         ShowToggle.Content = show ? "Hide" : "Show";
+    }
+
+    private static string Base()
+    {
+        var b = App.Config.Forge.BaseUrl?.TrimEnd('/');
+        return string.IsNullOrWhiteSpace(b) ? "https://sp-mod.com" : b;
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "ProductName": "Dragon Den Mod Manager",
   "Forge": {
-    "BaseUrl": "https://forge.sp-tarkov.com",
+    "BaseUrl": "https://sp-mod.com",
     "Token": ""
   },
   "Paths": {


### PR DESCRIPTION
## Why

The SPT Forge shut down `forge.sp-tarkov.com` around Aug 12, 2026 and relaunched at **sp-mod.com**. The mod manager can no longer reach the API, so browsing/refreshing fails for everyone.

The new Forge runs the same `api/v0` API (same endpoints and response envelope), with files served from `files.sp-mod.com` and downloads via `sp-mod.com/mod/download/{id}/{slug}/{version}`. Notably it **answers without a bearer token** (verified against `mods`, `mod/{id}`, `mod/{id}/versions`, `mod-categories`, `ping`).

## Changes

- **Domain migration**: default `Forge.BaseUrl` → `https://sp-mod.com` (Config defaults, ForgeClient fallback, bundled appsettings.json, TokenDialog ping/validation URLs). Existing user configs pointing at `sp-tarkov.com` are auto-rewritten on load, so current installs heal themselves.
- **Token now optional**: the first-run flow previously hard-blocked until a token validated against the dead domain. The token dialog can now be skipped ("Continue without token"); a blank token sends no `Authorization` header (which `ForgeClient.NewGet` already supported). Non-blank tokens are still validated.
- **Parse fix**: the new API returns `spt_version_constraint` padded with whitespace (e.g. `" 4.0.10 "`); it is now trimmed at the parse site before storage/semver handling. All other parse sites were audited against live payloads (`fika_compatibility` string-on-versions vs bool-on-mods, null `hub_id`, absolute thumbnail URLs, download `link`) and already handle the new shapes.
- **Self-update check disabled**: the manager's Forge listing (mod 2396) was not migrated to sp-mod.com, so the startup check 404s into the 10-attempt retry/backoff path on every launch, flashing "Network trouble" status messages. Early-returns with a comment until an update channel exists again; the code is kept.

## Verified

- Builds clean (0 errors).
- Launched against a real existing install: config auto-migrated, cache incrementally synced from sp-mod.com (pulled a mod published the same day), thumbnails load from files.sp-mod.com, constraints stored trimmed.
- A stale sp-tarkov token in config is harmless — sp-mod.com returns 200 for unknown bearer tokens.

Per the LICENSE, this contribution is provided under CC BY-NC-ND 4.0 with the stated grant to the project owner.